### PR TITLE
Update react-native-push-notification-ios and add expo-notifications

### DIFF
--- a/docs/react-native/docs/overview.md
+++ b/docs/react-native/docs/overview.md
@@ -27,9 +27,10 @@ With Notifee requiring a paid license for release builds, we appreciate this mod
 Open Source alternatives are available if required:
 
 - [wix/react-native-notifications](https://github.com/wix/react-native-notifications).
-- [react-native-community/react-native-push-notifications-ios](https://github.com/react-native-community/react-native-push-notification-ios).
+- [react-native-push-notifications-ios](https://github.com/react-native-push-notification-ios/push-notification-ios).
 - [zo0r/react-native-push-notification](https://github.com/zo0r/react-native-push-notification).
 - [invertase/react-native-firebase](https://v5.rnfirebase.io/docs/v5.x.x/notifications/introduction) (version 5 only).
+- [expo-notifications](https://docs.expo.io/push-notifications/overview/)
 
 Paid licenses allow us to ensure the library is well maintained & ensures on-going support to the user base. To learn more
 see our [Frequently Asked Questions](/frequently-asked-questions).

--- a/docs/react-native/docs/overview.md
+++ b/docs/react-native/docs/overview.md
@@ -27,7 +27,7 @@ With Notifee requiring a paid license for release builds, we appreciate this mod
 Open Source alternatives are available if required:
 
 - [wix/react-native-notifications](https://github.com/wix/react-native-notifications).
-- [react-native-push-notifications-ios](https://github.com/react-native-push-notification-ios/push-notification-ios).
+- [react-native-push-notification-ios](https://github.com/react-native-push-notification-ios/push-notification-ios).
 - [zo0r/react-native-push-notification](https://github.com/zo0r/react-native-push-notification).
 - [invertase/react-native-firebase](https://v5.rnfirebase.io/docs/v5.x.x/notifications/introduction) (version 5 only).
 - [expo-notifications](https://docs.expo.io/push-notifications/overview/)


### PR DESCRIPTION
- react-native-push-notification-ios now lives in its own org outside of react-native-community
- expo-notifications is a good free & open source alternative that works directly with APNS/FCM or the Expo push service