### PR TITLE
docs(installation): add instructions for new local repo integration in android

### DIFF
--- a/docs/react-native/docs/installation.md
+++ b/docs/react-native/docs/installation.md
@@ -18,8 +18,35 @@ npm install --save @notifee/react-native
 yarn add @notifee/react-native
 ```
 
-## 2. Autolinking with React Native
 
+## 2. Android: Add local maven repository
+
+The Notifee core library is packaged an Android "AAR" file. It is distributed in a "local maven repository" for Android integration.
+
+You must add this repository to your `android/build.gradle` build script file.
+
+Open `android/build.gradle` for editing, and add these lines in your `allprojects` `repositories` section:
+
+
+```groovy
+
+allprojects {
+
+  // ... you may have other items before the "repositories" section, that is fine
+
+  repositories {
+
+    // ... you will already have some local repositories defined ...
+
+    // ADD THIS BLOCK - this is how Notifee finds it's Android library:
+    maven {
+      url "$rootDir/../node_modules/@notifee/react-native/android/libs"
+    }
+  }
+}
+```
+
+## 3. Autolinking with React Native
 Users on React Native 0.60+ automatically have access to "[autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md)",
 requiring no further manual installation steps. To automatically link the package, rebuild your project:
 

--- a/docs/react-native/docs/release-notes.md
+++ b/docs/react-native/docs/release-notes.md
@@ -5,6 +5,9 @@ next: /react-native/docs/usage
 previous: /react-native/docs/license-keys
 ---
 
+## (unreleased)
+- **[Android]: BREAKING CHANGE** - you must add a new maven local repository to your `android/build.gradle` file. (Fixes [#151](https://github.com/notifee/react-native-notifee/issues/151)). See step #2 in [the installation guide](https://notifee.app/react-native/docs/installation)
+
 ## 1.10.1
 - **[Android]**: Fixes an issue on Android to prevent `cancelDisplayedNotifications` cancelling trigger notifications. (Fixes [#349](https://github.com/notifee/react-native-notifee/issues/349))
 


### PR DESCRIPTION


also added release note block for future release

Related invertase/notifee#107 and notifee/react-native-notifee#370